### PR TITLE
Compatibility fix for netsquid-magic version change

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -7,10 +7,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-    - name: Set up Python 3.8
+    - name: Set up Python 3.9
       uses: actions/setup-python@v1
       with:
-        python-version: 3.8
+        python-version: 3.9
     - name: Install pypa/build
       run: >-
         python -m

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+2025-05-13 (0.13.5)
+-------------------
+- Fix compatibility issue in MagicNetworkLayerProtocol due to changes in netsquid-magic
+- Add requirement on netsquid-magic >= 16.0.0, < 17.0.0
+
 2024-12-16 (0.13.4)
 ------------------
 - Bugfix for simulation time not resetting between different calls of the `squidasm.run.stack.run.run` method

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,6 +21,7 @@ install_requires =
     pydantic >=1.8.2, < 3.0
     pydynaa >=0.3, <2.0
     netsquid >=1.1.2, <2.0
+    netsquid-magic >= 16.0.0, <17.0.0
     bitarray >=2.8.0, <3.0.0
     netqasm >=0.11.2
     pytest >=7.1, <8.0

--- a/squidasm/sim/network/network.py
+++ b/squidasm/sim/network/network.py
@@ -353,7 +353,8 @@ class MagicNetworkLayerProtocol(MagicLinkLayerProtocol):
         # netsquid_magic package, with one change: the `messages` dict is
         # returned at the end, so that their contents can be logged.
         try:
-            queue_item = self._pop_from_requests_in_process(event)
+            delivery = self._magic_distributor.peek_delivery(event)
+            queue_item = self._pop_from_requests_in_process(delivery)
         except KeyError:
             # This indicates that this delivery event is not the "reference" delivery event returned by add_delivery
             # of the magic distributor. Since the below operations only need to be executed once, we can skip this.


### PR DESCRIPTION
Fix for MagicNetworkLayerProtocol due to change of netsquid-magic to 16.0.0
Add explicit requirement ot netsquid-magic