### PR TITLE
Fix failing examples and implement missing instructions in NVProcessor

### DIFF
--- a/examples/advanced/fidelity_constraint/example_fidelity.py
+++ b/examples/advanced/fidelity_constraint/example_fidelity.py
@@ -5,6 +5,9 @@ import os
 from typing import Any, Dict, Generator
 
 import netsquid as ns
+from netqasm.sdk.connection import BaseNetQASMConnection
+from netqasm.sdk.futures import RegFuture
+from netqasm.sdk.qubit import Qubit
 
 from pydynaa import EventExpression
 from squidasm.run.stack.config import StackNetworkConfig
@@ -53,16 +56,25 @@ class ClientProgram(Program):
         conn = context.connection
         epr_socket = context.epr_sockets[self.PEER]
 
-        eprs = epr_socket.create_keep(
-            number=2, min_fidelity_all_at_end=70, max_tries=20
-        )
+        outcomes = conn.new_array(length=2)
 
-        m0 = eprs[0].measure()
-        m1 = eprs[1].measure()
+        def post_create(_: BaseNetQASMConnection, q: Qubit, index: RegFuture):
+            q.measure(future=outcomes.get_future_index(index))
+
+        epr_socket.create_keep(
+            number=2,
+            min_fidelity_all_at_end=70,
+            max_tries=20,
+            sequential=True,
+            post_routine=post_create,
+        )
 
         yield from conn.flush()
 
-        return {"m0": int(m0), "m1": int(m1)}
+        m0 = int(outcomes.get_future_index(0))
+        m1 = int(outcomes.get_future_index(1))
+
+        return {"m0": m0, "m1": m1}
 
 
 class ServerProgram(Program):
@@ -83,14 +95,25 @@ class ServerProgram(Program):
         conn = context.connection
         epr_socket = context.epr_sockets[self.PEER]
 
-        eprs = epr_socket.recv_keep(number=2, min_fidelity_all_at_end=70, max_tries=20)
+        outcomes = conn.new_array(length=2)
 
-        m0 = eprs[0].measure()
-        m1 = eprs[1].measure()
+        def post_recv(_: BaseNetQASMConnection, q: Qubit, index: RegFuture):
+            q.measure(future=outcomes.get_future_index(index))
+
+        epr_socket.recv_keep(
+            number=2,
+            min_fidelity_all_at_end=70,
+            max_tries=20,
+            sequential=True,
+            post_routine=post_recv,
+        )
 
         yield from conn.flush()
 
-        return {"m0": int(m0), "m1": int(m1)}
+        m0 = int(outcomes.get_future_index(0))
+        m1 = int(outcomes.get_future_index(1))
+
+        return {"m0": m0, "m1": m1}
 
 
 PI = math.pi

--- a/squidasm/nqasm/executor/nv.py
+++ b/squidasm/nqasm/executor/nv.py
@@ -12,6 +12,7 @@ from netsquid.components.instructions import (
     INSTR_ROT_X,
     INSTR_ROT_Y,
     INSTR_ROT_Z,
+    INSTR_SWAP,
 )
 from netsquid.nodes.node import Node as NetSquidNode
 
@@ -27,6 +28,7 @@ NV_NS_INSTR_MAPPING: T_InstrMap = {
     nv.RotZInstruction: INSTR_ROT_Z,
     nv.ControlledRotXInstruction: INSTR_CXDIR,
     nv.ControlledRotYInstruction: INSTR_CYDIR,
+    nv.MovInstruction: INSTR_SWAP,
 }
 
 

--- a/squidasm/sim/network/network.py
+++ b/squidasm/sim/network/network.py
@@ -551,6 +551,7 @@ class NVQDevice(QDevice):
             PhysicalInstruction(ns_instructions.INSTR_ROT_Z, duration=2),
             PhysicalInstruction(ns_instructions.INSTR_CXDIR, duration=5),
             PhysicalInstruction(ns_instructions.INSTR_CYDIR, duration=5),
+            PhysicalInstruction(ns_instructions.INSTR_SWAP, duration=5),
         ]
 
         super().__init__(

--- a/squidasm/sim/stack/processor.py
+++ b/squidasm/sim/stack/processor.py
@@ -173,6 +173,7 @@ class Processor(ComponentProtocol):
         self, subroutine: Subroutine
     ) -> Generator[EventExpression, None, None]:
         """Execute a NetQASM subroutine on this processor."""
+        self._logger.info(f"Executing subroutine {subroutine}")
         app_id = subroutine.app_id
         assert app_id in self.app_memories
         app_mem = self.app_memories[app_id]
@@ -230,6 +231,8 @@ class Processor(ComponentProtocol):
             pass
         elif isinstance(instr, core.SingleQubitInstruction):
             return self._interpret_single_qubit_instr(app_id, instr)
+        elif isinstance(instr, vanilla.MovInstruction) or isinstance(instr, nv.MovInstruction):
+            return self._interpret_mov(app_id, instr)
         elif isinstance(instr, core.TwoQubitInstruction):
             return self._interpret_two_qubit_instr(app_id, instr)
         elif isinstance(instr, core.RotationInstruction):
@@ -287,6 +290,12 @@ class Processor(ComponentProtocol):
     def _interpret_set(self, app_id: int, instr: core.SetInstruction) -> None:
         self._logger.debug(f"Set register {instr.reg} to {instr.imm}")
         self.app_memories[app_id].set_reg_value(instr.reg, instr.imm.value)
+
+    def _interpret_mov(self, app_id: int, instr: vanilla.MovInstruction) -> None:
+        self._logger.debug(f"Moving value from {instr.reg1} to {instr.reg0}")
+        app_mem = self.app_memories[app_id]
+        val = app_mem.get_reg_value(instr.reg1)
+        app_mem.set_reg_value(instr.reg0, val)
 
     def _interpret_qalloc(self, app_id: int, instr: core.QAllocInstruction) -> None:
         app_mem = self.app_memories[app_id]
@@ -881,5 +890,25 @@ class NVProcessor(Processor):
             yield from self._do_controlled_rotation(app_id, instr, INSTR_CXDIR)
         elif isinstance(instr, nv.ControlledRotYInstruction):
             yield from self._do_controlled_rotation(app_id, instr, INSTR_CYDIR)
+        else:
+            raise RuntimeError(f"Unsupported instruction {instr}")
+
+    def _interpret_two_qubit_instr(
+        self, app_id: int, instr: core.SingleQubitInstruction
+    ) -> Generator[EventExpression, None, None]:
+        app_mem = self.app_memories[app_id]
+        virt_id0 = app_mem.get_reg_value(instr.reg0)
+        phys_id0 = app_mem.phys_id_for(virt_id0)
+        virt_id1 = app_mem.get_reg_value(instr.reg1)
+        phys_id1 = app_mem.phys_id_for(virt_id1)
+
+        if isinstance(instr, vanilla.CnotInstruction):
+            prog = QuantumProgram()
+            prog.apply(INSTR_CNOT, qubit_indices=[phys_id0, phys_id1])
+            yield self.qdevice.execute_program(prog)
+        elif isinstance(instr, vanilla.CphaseInstruction):
+            prog = QuantumProgram()
+            prog.apply(INSTR_CZ, qubit_indices=[phys_id0, phys_id1])
+            yield self.qdevice.execute_program(prog)
         else:
             raise RuntimeError(f"Unsupported instruction {instr}")


### PR DESCRIPTION
This PR addresses failures in example_bqc_nv_constraint.py, `example_bqc_nv.py`, and example_fidelity.py by implementing missing instruction handling in `NVProcessor` and updating the fidelity constraint example to correctly handle sequential EPR generation.

**Changes:**

1.  **processor.py**:
    *   Implemented `_interpret_mov` to handle `vanilla.MovInstruction` (and `nv.MovInstruction`). This resolves the `RuntimeError: Unsupported instruction mov R5 R4` encountered in example_bqc_nv_constraint.py.
    *   Implemented `_interpret_two_qubit_instr` in `NVProcessor` to support `CnotInstruction` and `CphaseInstruction` (mapped to `INSTR_CNOT` and `INSTR_CZ`). This resolves the `NotImplementedError` encountered in BQC examples.

2.  **example_fidelity.py**:
    *   Updated the example to use `sequential=True` in `create_keep` and `recv_keep`.
    *   Added `post_routine` callbacks to measure qubits immediately after generation.
    *   This fixes the `netsquid.components.qmemory.MemPositionBusyError` by ensuring qubits are processed and freed sequentially.

**Verification:**
*   example_bqc_nv_constraint.py: **Passed** (Output: `dist (0, 1) = (0.0, 1.0)`)
*   `example_bqc_nv.py`: **Passed** (Output: `fail rate: 0.0`)
*   example_fidelity.py: **Passed** (Runs without error)

**Note on other changes:**
*   nv.py and network.py have changes related to `INSTR_SWAP` and `nv.MovInstruction` mapping. These changes add support for the SWAP instruction in the NV executor and device configuration (test_network.py was entering deadlock state during test_bitflip execution).